### PR TITLE
Adjust pm2 config and memory allowance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN npm install
 RUN npm install -g pm2
 
 EXPOSE 8081
-CMD ["pm2", "start", "/opt/kamu/index.js", "-i", "0", "--no-daemon", "--no-color"]
+CMD ["pm2-docker", "-i", "8", "/opt/kamu/index.js"]
 

--- a/k8s.yml
+++ b/k8s.yml
@@ -20,10 +20,10 @@ spec:
         image: {{.Image}}
         resources:
           requests:
-            memory: "1.0Gi"
+            memory: "1.5Gi"
             cpu: "1000m"
           limits:
-            memory: "1.0Gi"
+            memory: "1.5Gi"
             cpu: "1000m"
         ports:
           - containerPort: 8081


### PR DESCRIPTION
pm2-docker is optimized for use in docker. The previous settings used
NUMPROCS processes, which on a c3.8xl machine like used in prod-v1 means
32 processes, even though the cpu limit was set much lower. Lastly, kamu
was getting killed for OOMing at 1GB.

CLOUD-636