### PR TITLE
Use extensions/v1beta1 for Kube deployment

### DIFF
--- a/k8s.yml
+++ b/k8s.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kamu
@@ -70,4 +70,3 @@ spec:
     apiVersion: autoscaling/v1
     kind: Deployment
     name: kamu
-


### PR DESCRIPTION
This is so it works in both our 1.5 (imugi) and 1.6 (prod-v1) clusters.

CLOUD-651