### PR TITLE
Use entire c3.8xl nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN npm install
 RUN npm install -g pm2
 
 EXPOSE 8081
-CMD ["pm2-docker", "-i", "8", "/opt/kamu/index.js"]
+CMD ["pm2-docker", "-i", "32", "/opt/kamu/index.js"]
 

--- a/k8s.yml
+++ b/k8s.yml
@@ -21,10 +21,10 @@ spec:
         resources:
           requests:
             memory: "20Gi"
-            cpu: "25600m"
+            cpu: "23700m"
           limits:
             memory: "20Gi"
-            cpu: "25600m"
+            cpu: "23700m"
         ports:
           - containerPort: 8081
             name: http
@@ -70,4 +70,3 @@ spec:
     apiVersion: autoscaling/v1
     kind: Deployment
     name: kamu
-

--- a/k8s.yml
+++ b/k8s.yml
@@ -20,11 +20,11 @@ spec:
         image: {{.Image}}
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1000m"
+            memory: "20Gi"
+            cpu: "25600m"
           limits:
-            memory: "2Gi"
-            cpu: "1000m"
+            memory: "20Gi"
+            cpu: "25600m"
         ports:
           - containerPort: 8081
             name: http
@@ -63,8 +63,8 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: kamu
 spec:
-  targetCPUUtilizationPercentage: 40
-  minReplicas: 20
+  targetCPUUtilizationPercentage: 50
+  minReplicas: 4
   maxReplicas: 50
   scaleTargetRef:
     apiVersion: autoscaling/v1


### PR DESCRIPTION
Kamu makes other services hate life. By requesting huge resources, it
will get effectively dedicated nodes and should impact other services
less.