### PR TITLE
Add prod-v2 k8s.yml with larger mem/cpu requirements

### DIFF
--- a/k8s-prod-v2.yml
+++ b/k8s-prod-v2.yml
@@ -1,0 +1,72 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: kamu
+spec:
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  revisionHistoryLimit: 1
+  template:
+    metadata:
+      labels:
+        app: kamu
+        env: prod
+    spec:
+      containers:
+      - name: kamu
+        # rendered by kube-deploy
+        image: {{.Image}}
+        resources:
+          requests:
+            memory: "40Gi"
+            cpu: "55000m"
+          limits:
+            memory: "40Gi"
+            cpu: "55000m"
+        ports:
+          - containerPort: 8081
+            name: http
+        readinessProbe:
+          httpGet:
+            path: "/status"
+            port: 8081
+          initialDelaySeconds: 5
+        env:
+          - name: KAMU_KEY
+            valueFrom:
+              secretKeyRef:
+                name: kamu
+                key: kamu_key
+          - name: KAMU_HOST
+            value: ""
+          - name: KAMU_PORT
+            value: "8081"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kamu
+spec:
+  type: NodePort
+  ports:
+    - port: 31842
+      nodePort: 31842 # this is the port ELB should be pointed at
+      targetPort: http
+      protocol: TCP
+  selector:
+    app: kamu
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: kamu
+spec:
+  targetCPUUtilizationPercentage: 50
+  minReplicas: 4
+  maxReplicas: 50
+  scaleTargetRef:
+    apiVersion: autoscaling/v1
+    kind: Deployment
+    name: kamu


### PR DESCRIPTION
To force Kube to kamu pods put on it's own node since it's
known to misbehave if other services are on the node.

The CPU requirement is ~90% of the allocatable for prod-v2 nodes
MEM requirement is double what is used for prod-v1

VELO-814