### PR TITLE
Velo 814 prod v2 k8s 2

### DIFF
--- a/k8s-prod-v2.yml
+++ b/k8s-prod-v2.yml
@@ -21,10 +21,10 @@ spec:
         resources:
           requests:
             memory: "40Gi"
-            cpu: "33750m"
+            cpu: "33500m"
           limits:
             memory: "40Gi"
-            cpu: "33750m"
+            cpu: "33500m"
         ports:
           - containerPort: 8081
             name: http

--- a/k8s-prod-v2.yml
+++ b/k8s-prod-v2.yml
@@ -21,10 +21,10 @@ spec:
         resources:
           requests:
             memory: "40Gi"
-            cpu: "55000m"
+            cpu: "33750m"
           limits:
             memory: "40Gi"
-            cpu: "55000m"
+            cpu: "33750m"
         ports:
           - containerPort: 8081
             name: http


### PR DESCRIPTION
Current allocations for a prod-v2 node:

Daemon | CPU | Mem
-- | -- | --
Dd agent | 1500m | 750Mi
Ping | 250m | 100Mi
Sumologic | 100m (max) | (max)
Calico | 100m (max) | (max)
Kubeproxy | 100m (max) | (max)
Node-problem detector | 200m | 100Mi
Total: | 2250m | 950Mi
Allocatable | 36000m | 61734Mi
Difference | 33750m | 60784Mi

I chose `33500m` CPU for Kamu, didn't want to use all the balance of the `33750m`.

VELO-814