### PR TITLE
Allow kamu to run on smaller resource requests

### DIFF
--- a/k8s-prod-v2.yml
+++ b/k8s-prod-v2.yml
@@ -20,11 +20,11 @@ spec:
         image: {{.Image}}
         resources:
           requests:
-            memory: "40Gi"
-            cpu: "33500m"
+            memory: "20Gi"
+            cpu: "10"
           limits:
-            memory: "40Gi"
-            cpu: "33500m"
+            memory: "25Gi"
+            cpu: "15"
         ports:
           - containerPort: 8081
             name: http


### PR DESCRIPTION
Kamu should be able to share node resources with other deployments; reduce its requested resources so that other pods can schedule (including daemonsets).