### PR TITLE
[WPADS-359] update url parsing (security warning)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 'use strict';
 
 // built-in/third-party modules
-var Crypto      = require( 'crypto' ),
-    Url         = require( 'url' );
+var Crypto      = require( 'crypto' );
 
 // custom modules
 var config      = require( './config' ),
@@ -30,7 +29,7 @@ module.exports.processRequest = function( req, res ) {
       urlType,
       hmac;
 
-  url = Url.parse( req.url );
+  url = new URL( req.url, 'http://localhost' );
 
   mediaHeaders = {
     'Via': config.proxyAgent,
@@ -101,7 +100,7 @@ module.exports.processRequest = function( req, res ) {
     }
     signature = hmac.digest( 'hex' );
     if ( signature === reqSignature ) {
-      return proxy.processUrl( Url.parse( destUrl ), mediaHeaders, res, { 'redirects': config.maxRedirects, 'transform': mediaTransform, 'reqUrl': url.format() } );
+      return proxy.processUrl( new URL( destUrl ), mediaHeaders, res, { 'redirects': config.maxRedirects, 'transform': mediaTransform, 'reqUrl': req.url } );
     }
     else {
       return utils.fourOhFour( res, 'signature mismatch: ' + signature + ' | ' + reqSignature );

--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -3,7 +3,6 @@
 // built-in/third-party modules
 var Http        = require( 'http' ),
     Https       = require( 'https' ),
-    Url         = require( 'url' ),
     _           = require( 'lodash' );
 
 // custom modules
@@ -79,7 +78,7 @@ var processUrl = function( url, mediaHeaders, res, options ) {
         } );
 
         if ( res._media.pendingTransform ) {
-          transformer = transform.getTransformer( res, mediaRes, options.transform, options.reqUrl, url.format() );
+          transformer = transform.getTransformer( res, mediaRes, options.transform, options.reqUrl, url.href );
         }
 
         newHeaders = {
@@ -142,12 +141,12 @@ var processUrl = function( url, mediaHeaders, res, options ) {
             else {
               res._media.finished = false;
 
-              newUrl = Url.parse( mediaRes.headers[ 'location' ] );
-              if ( !( ( newUrl.host != null ) && ( newUrl.hostname != null ) ) ) {
-                newUrl.host = newUrl.hostname = url.hostname;
-                newUrl.protocol = url.protocol;
+              try {
+                newUrl = new URL( mediaRes.headers[ 'location' ], url.href );
+              } catch (e) {
+                return utils.fourOhFour( res, 'Invalid redirect location', url );
               }
-              log.debug( 'Redirected to ' + ( newUrl.format() ) );
+              log.debug( 'Redirected to ' + newUrl.href );
               redirectOptions = _.clone( options );
               redirectOptions.redirects = redirectsLeft - 1;
               return processUrl( newUrl, mediaHeaders, res, redirectOptions );

--- a/src/proxy/transform.js
+++ b/src/proxy/transform.js
@@ -1,8 +1,7 @@
 'use strict';
 
 // built-in/third-party modules
-var Url         = require( 'url' ),
-    _           = require( 'lodash' );
+var _           = require( 'lodash' );
 
 // custom modules
 var config      = require( '../config' ),
@@ -199,12 +198,12 @@ var getTransformer = function( res, mediaRes, options, reqUrl, mediaUrl ) {
         // only log if redirect on error is set, otherwise let the fiveHundred logs the error
         log.error( 'failed transforming image', errorObj );
 
-        var redirectUrl = Url.parse( reqUrl, true );
+        var isAbsolute = /^https?:\/\//i.test(reqUrl);
+        var redirectUrl = new URL( reqUrl, 'http://localhost' );
 
         // remove any transform information from the url
-        redirectUrl.search = '';
         for ( var i = 0, j = config.transformOptions.length; i < j; i++ ) {
-          delete redirectUrl.query[ config.transformOptions[ i ] ];
+          redirectUrl.searchParams.delete( config.transformOptions[ i ] );
         }
         var redirectPath = redirectUrl.pathname.split( '/' );
         if ( redirectPath.length > 3 ) { // 3 === leading slash and two paramenters
@@ -212,14 +211,16 @@ var getTransformer = function( res, mediaRes, options, reqUrl, mediaUrl ) {
         }
         redirectUrl.pathname = redirectPath.join( '/' );
 
+        var loc = isAbsolute ? redirectUrl.href : redirectUrl.pathname + redirectUrl.search + redirectUrl.hash;
+
         // redirect the request
         res.writeHead( 302, {
-          'Location': redirectUrl.format()
+          'Location': loc
         } );
         return utils.finish( res );
       }
       else {
-        return utils.fiveHundred( res, 'Failed transforming media', Url.parse( mediaUrl ), errorObj );
+        return utils.fiveHundred( res, 'Failed transforming media', new URL( mediaUrl, 'http://localhost' ), errorObj );
       }
     } );
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -45,7 +45,7 @@ var writeHeadersWithStatusAndContentType = function( res, statusCode, contentTyp
  * @param   object    url     url object
  */
 var fourOhFour = function( res, msg, url ) {
-  log.warn( msg + ': ' + ( ( url != null ? url.format() : void 0 ) || 'unknown' ) );
+  log.warn( msg + ': ' + ( ( url != null ? (url.href || (typeof url.format === 'function' ? url.format() : url.toString())) : void 0 ) || 'unknown' ) );
 
   writeHeadersWithStatusAndContentType( res, 200, 'image/jpeg' );
   finish( res, placeholderImage );
@@ -61,7 +61,7 @@ module.exports.fourOhFour = fourOhFour;
  * @param   object    err     error object to log
  */
 var fiveHundred = function( res, msg, url, err ) {
-  log.error( msg + ': ' + ( ( url != null ? url.format() : void 0 ) || 'unknown' ), err );
+  log.error( msg + ': ' + ( ( url != null ? (url.href || (typeof url.format === 'function' ? url.format() : url.toString())) : void 0 ) || 'unknown' ), err );
   writeHeadersWithStatusAndContentType( res, 500 );
   return finish( res, 'Internal Error' );
 };
@@ -100,7 +100,8 @@ var getQS = function( url ) {
     }
 
     if ( url.search && url.search !== '' ) {
-      return QueryString.parse( url.search );
+      var searchStr = url.search.charAt(0) === '?' ? url.search.substring(1) : url.search;
+      return QueryString.parse( searchStr );
     }
   }
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -3,7 +3,6 @@
 require( '../common' );
 
 var http      = require( 'http' ),
-    Url       = require( 'url' ),
     fs        = require( 'fs' ),
     proxyUrl  = require( '../../demo/utils' ).proxyUrl,
     server;
@@ -16,8 +15,8 @@ var proxyPath = function( externalUrl ) {
   if ( externalUrl == null ) {
     return '';
   }
-  url = Url.parse( proxyUrl( externalUrl ) );
-  return url.path;
+  url = new URL( proxyUrl( externalUrl ) );
+  return url.pathname + url.search + url.hash;
 };
 
 describe( 'app integration ->', function() {

--- a/test/specs/src/index.spec.js
+++ b/test/specs/src/index.spec.js
@@ -12,6 +12,7 @@ describe( 'app index', function() {
     config = require( '../../../src/config' );
 
     fakeReq = {
+      'url': '/encoded-key/encoded-url',
       'headers': {
         'SomeHeaderKey': 'SomeHeaderValue'
       }
@@ -27,16 +28,6 @@ describe( 'app index', function() {
           'digest'        : sinon.stub().returns( 'encoded-key' )
         } )
       },
-      'Url'           : {
-        'parse'         : sinon.stub().returns( {
-          'host':     'www.some-domain.com',
-          'hostname': 'www.some-domain.com',
-          'pathname': '/encoded-key/encoded-url',
-          'protocol': 'http:',
-          'port': 80,
-          'format': function(){}
-        } )
-      },
       'log'           : {
         'debug'         : function(){},
         'warn'          : function(){},
@@ -47,7 +38,7 @@ describe( 'app index', function() {
         'parseQS'       : sinon.stub()
       },
       'schema'        : {
-        'decodeUrl'     : sinon.stub().returns( 'decoded-url' )
+        'decodeUrl'     : sinon.stub().returns( 'http://decoded-url.com/image.jpg' )
       },
       'proxy'         : {
         'processUrl'    : sinon.stub()
@@ -75,7 +66,6 @@ describe( 'app index', function() {
 
     describe( 'when failing to decode from url', function() {
       var bkpDecodeUrl,
-          newUrlParse,
           bkpPathname,
           bkpGetQS;
 
@@ -83,10 +73,8 @@ describe( 'app index', function() {
         bkpDecodeUrl = index.__get__( 'schema' ).decodeUrl();
         index.__get__( 'schema' ).decodeUrl.returns( void 0 );
 
-        newUrlParse = index.__get__( 'Url' ).parse();
-        bkpPathname = newUrlParse.pathname;
-        newUrlParse.pathname = '/encoded-key?url=encoded-url-from-qs';
-        index.__get__( 'Url' ).parse.returns( newUrlParse );
+        bkpPathname = fakeReq.url;
+        fakeReq.url = '/encoded-key?url=encoded-url-from-qs';
 
         bkpGetQS = index.__get__( 'utils' ).getQS();
         index.__get__( 'utils' ).getQS.returns( {
@@ -96,8 +84,7 @@ describe( 'app index', function() {
 
       after( function() {
         index.__get__( 'schema' ).decodeUrl.returns( bkpDecodeUrl );
-        newUrlParse.pathname = bkpPathname;
-        index.__get__( 'Url' ).parse.returns( newUrlParse );
+        fakeReq.url = bkpPathname;
         index.__get__( 'utils' ).getQS.returns( bkpGetQS );
       } );
 
@@ -111,7 +98,6 @@ describe( 'app index', function() {
 
     describe( 'when failing to decode media from url and querystring', function() {
       var bkpDecodeUrl,
-          newUrlParse,
           bkpPathname,
           bkpGetQS;
 
@@ -119,10 +105,8 @@ describe( 'app index', function() {
         bkpDecodeUrl = index.__get__( 'schema' ).decodeUrl();
         index.__get__( 'schema' ).decodeUrl.returns( void 0 );
 
-        newUrlParse = index.__get__( 'Url' ).parse();
-        bkpPathname = newUrlParse.pathname;
-        newUrlParse.pathname = '/encoded-key';
-        index.__get__( 'Url' ).parse.returns( newUrlParse );
+        bkpPathname = fakeReq.url;
+        fakeReq.url = '/encoded-key';
 
         bkpGetQS = index.__get__( 'utils' ).getQS();
         index.__get__( 'utils' ).getQS.returns( {} );
@@ -130,8 +114,7 @@ describe( 'app index', function() {
 
       after( function() {
         index.__get__( 'schema' ).decodeUrl.returns( bkpDecodeUrl );
-        newUrlParse.pathname = bkpPathname;
-        index.__get__( 'Url' ).parse.returns( newUrlParse );
+        fakeReq.url = bkpPathname;
         index.__get__( 'utils' ).getQS.returns( bkpGetQS );
       } );
 
@@ -148,15 +131,12 @@ describe( 'app index', function() {
           bkpPathname;
 
       before( function() {
-        newUrlParse = index.__get__( 'Url' ).parse();
-        bkpPathname = newUrlParse.pathname;
-        newUrlParse.pathname = '/encoded-key/encoded-url/transform_options';
-        index.__get__( 'Url' ).parse.returns( newUrlParse );
+        bkpPathname = fakeReq.url;
+        fakeReq.url = '/encoded-key/encoded-url/transform_options';
       } );
 
       after( function() {
-        newUrlParse.pathname = bkpPathname;
-        index.__get__( 'Url' ).parse.returns( newUrlParse );
+        fakeReq.url = bkpPathname;
       } );
 
       it( 'should try to parse transform options from url', function() {
@@ -173,10 +153,8 @@ describe( 'app index', function() {
           bkpGetQS;
 
       before( function() {
-        newUrlParse = index.__get__( 'Url' ).parse();
-        bkpPathname = newUrlParse.pathname;
-        newUrlParse.pathname = '/encoded-key/encoded-url';
-        index.__get__( 'Url' ).parse.returns( newUrlParse );
+        bkpPathname = fakeReq.url;
+        fakeReq.url = '/encoded-key/encoded-url';
 
         bkpGetQS = index.__get__( 'utils' ).getQS();
         index.__get__( 'utils' ).getQS.returns( {
@@ -185,8 +163,7 @@ describe( 'app index', function() {
       } );
 
       after( function() {
-        newUrlParse.pathname = bkpPathname;
-        index.__get__( 'Url' ).parse.returns( newUrlParse );
+        fakeReq.url = bkpPathname;
         index.__get__( 'utils' ).getQS.returns( bkpGetQS );
       } );
 
@@ -220,15 +197,12 @@ describe( 'app index', function() {
           bkpPathname;
 
       before( function() {
-        newUrlParse = index.__get__( 'Url' ).parse();
-        bkpPathname = newUrlParse.pathname;
-        newUrlParse.pathname = '//encoded-url';
-        index.__get__( 'Url' ).parse.returns( newUrlParse );
+        bkpPathname = fakeReq.url;
+        fakeReq.url = '//encoded-url';
       } );
 
       after( function() {
-        newUrlParse.pathname = bkpPathname;
-        index.__get__( 'Url' ).parse.returns( newUrlParse );
+        fakeReq.url = bkpPathname;
       } );
 
       it( 'should return not found', function() {

--- a/test/specs/src/proxy/index.spec.js
+++ b/test/specs/src/proxy/index.spec.js
@@ -2,8 +2,6 @@
 
 require( '../../../common' );
 
-var Url = require( 'url' );
-
 describe( 'proxy index', function() {
 
   var index,
@@ -33,15 +31,6 @@ describe( 'proxy index', function() {
       'Https'         : {
         'get'           : sinon.stub().returns( fakeProtocol )
       },
-      'Url'           : {
-        'parse'         : sinon.stub().returns( {
-          'host':     'www.some-domain.com',
-          'hostname': 'www.some-domain.com',
-          'protocol': 'http:',
-          'port': 80,
-          'format': function(){}
-        } )
-      },
       'log'           : {
         'debug'         : function(){},
         'error'         : sinon.stub(),
@@ -67,7 +56,7 @@ describe( 'proxy index', function() {
 
     before( function() {
       index.__get__( 'utils' ).fourOhFour.returns( 'return from fourOhFour' );
-      urlTest = Url.parse( 'http://www.some-domain.com/some/path' );
+      urlTest = new URL( 'http://www.some-domain.com/some/path' );
     } );
 
     after( function() {
@@ -75,15 +64,15 @@ describe( 'proxy index', function() {
     } );
 
     describe( 'when asset url host is NOT defined', function() {
-      var bkpHost;
+      var bkpUrlTest;
 
       before( function() {
-        bkpHost = urlTest.host;
-        urlTest.host = void 0;
+        bkpUrlTest = urlTest;
+        urlTest = { protocol: 'http:' };
       } );
 
       after( function() {
-        urlTest.host = bkpHost;
+        urlTest = bkpUrlTest;
       } );
 
       it( 'should respond with a 404', function() {
@@ -97,15 +86,15 @@ describe( 'proxy index', function() {
 
     describe( 'when asset url host is defined', function() {
       describe( 'with an INVALID protocol', function() {
-        var bkpProtocol;
+        var bkpUrlTest;
 
         before( function() {
-          bkpProtocol = urlTest.protocol;
-          urlTest.protocol = 'invalid';
+          bkpUrlTest = urlTest;
+          urlTest = { host: 'www.some-domain.com', protocol: 'invalid' };
         } );
 
         after( function() {
-          urlTest.protocol = bkpProtocol;
+          urlTest = bkpUrlTest;
         } );
 
         it( 'should return a 404 response', function() {
@@ -696,19 +685,15 @@ describe( 'proxy index', function() {
                 } );
 
                 describe( 'when the location does NOT have a host', function() {
-                  var bkpParse;
+                  var bkpLocation;
 
                   before( function() {
-                    bkpParse = index.__get__( 'Url' ).parse();
-                    index.__get__( 'Url' ).parse.returns( {
-                      'protocol': 'http:',
-                      'port': 80,
-                      'format': function(){}
-                    } );
+                    bkpLocation = fakeExternalResponse.headers.location;
+                    fakeExternalResponse.headers.location = '/some/path';
                   } );
 
                   after( function() {
-                    index.__get__( 'Url' ).parse.returns( bkpParse );
+                    fakeExternalResponse.headers.location = bkpLocation;
                   } );
 
                   it( 'should use the host of the current external request', function() {
@@ -722,19 +707,10 @@ describe( 'proxy index', function() {
                 describe( 'when the location does have a host', function() {
                   var bkpParse;
 
-                  before( function() {
-                    bkpParse = index.__get__( 'Url' ).parse();
-                    index.__get__( 'Url' ).parse.returns( {
-                      'host': 'new-domain.com',
-                      'hostname': 'new-domain.com',
-                      'protocol': 'http:',
-                      'port': 80,
-                      'format': function(){}
-                    } );
-                  } );
+                  before(function() { /* removed */ });
 
                   after( function() {
-                    index.__get__( 'Url' ).parse.returns( bkpParse );
+                    /* index.__get__('Url').parse.returns( bkpParse ); */
                   } );
 
                   it( 'should use received host', function() {

--- a/test/specs/src/proxy/media.spec.js
+++ b/test/specs/src/proxy/media.spec.js
@@ -2,8 +2,6 @@
 
 require( '../../../common' );
 
-var Url = require( 'url' );
-
 describe( 'proxy media', function() {
   var media;
 
@@ -31,7 +29,7 @@ describe( 'proxy media', function() {
         'headerKey' : 'headerValue'
       };
 
-      url = Url.parse( 'http://some-host.com/some/path/image.jpg' );
+      url = new URL( 'http://some-host.com/some/path/image.jpg' );
     } );
 
     afterEach( function() {

--- a/test/specs/src/utils/index.spec.js
+++ b/test/specs/src/utils/index.spec.js
@@ -2,8 +2,6 @@
 
 require( '../../../common' );
 
-var Url = require( 'url' );
-
 describe( 'utils index', function() {
   var utils;
 
@@ -64,7 +62,7 @@ describe( 'utils index', function() {
 
       res = {};
       msg = 'not found message';
-      url = Url.parse( 'http://some-host.com/path/to/image.jpg' );
+      url = new URL( 'http://some-host.com/path/to/image.jpg' );
     } );
 
     after( function() {
@@ -111,7 +109,7 @@ describe( 'utils index', function() {
 
       res = {};
       msg = 'not found message';
-      url = Url.parse( 'http://some-host.com/path/to/image.jpg' );
+      url = new URL( 'http://some-host.com/path/to/image.jpg' );
     } );
 
     after( function() {
@@ -222,14 +220,14 @@ describe( 'utils index', function() {
 
     describe( 'when url is informed, but no query or search available', function() {
       it( 'should return undefined', function() {
-        var result = utils.getQS( Url.parse( 'http://some-host.com/path/to/image.jpg' ) );
+        var result = utils.getQS( new URL( 'http://some-host.com/path/to/image.jpg' ) );
         expect( result ).to.be.undefined;
       } );
     } );
 
     describe( 'when url is informed with either a query or search property', function() {
       it( 'should parse it into an object and return it', function() {
-        var result = utils.getQS( Url.parse( 'http://some-host.com/path/to/image.jpg?key=val&key2=val2' ) );
+        var result = utils.getQS( new URL( 'http://some-host.com/path/to/image.jpg?key=val&key2=val2' ) );
         expect( result ).not.to.be.undefined;
         expect( result ).to.contain.keys( [ 'key', 'key2' ] );
       } );


### PR DESCRIPTION
https://nodejs.org/api/url.html


`The node:url module provides two APIs for working with URLs: a legacy API that is Node.js specific, and a newer API that implements the same [WHATWG URL Standard](https://url.spec.whatwg.org/) used by web browsers.`

We're using the legacy API and we get security warnings in the logs about that. Let's update.